### PR TITLE
Better error logging and prevent backup from killing process on recoverable error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+*.iml
 .DS_Store
 test-data
 tmp


### PR DESCRIPTION
This commit prevents the backup functions from killing the process on
error. The errors are now just reported to Warnf/Errorf in the calling
function `Run`. This should allow operators to determine the cause of
the error and fix the issue and the CRON/Backup to continue on the next
run